### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,22 @@ jobs:
     steps:
     - uses: actions/checkout@v2.5.0
     - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@v9
-    - name: Run the Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@v2
+      uses: nixbuild/nix-quick-install-action@v30
+    - name: Set up Nix cache
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
     - run: nix-build test.nix
   mac:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2.5.0
     - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@v9
-    - name: Run the Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@v2
+      uses: nixbuild/nix-quick-install-action@v30
+    - name: Set up Nix cache
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
     - run: nix-build test.nix


### PR DESCRIPTION
The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `DeterminateSystems/nix-installer-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.
